### PR TITLE
$format->formatId() return 'format' key instead of 'format_id'

### DIFF
--- a/src/Entity/Format.php
+++ b/src/Entity/Format.php
@@ -58,7 +58,7 @@ class Format extends AbstractEntity
 
     public function getFormatId(): ?string
     {
-        return $this->get('format');
+        return $this->get('format_id');
     }
 
     public function getContainer(): ?string


### PR DESCRIPTION
#183